### PR TITLE
Fix module data not being showed

### DIFF
--- a/psgdpr.php
+++ b/psgdpr.php
@@ -895,7 +895,7 @@ class Psgdpr extends Module
     {
         $modulesData = Hook::getHookModuleExecList('actionExportGDPRData'); // get modules using the export gdpr hook
 
-        if (empty($modulesData) || count($modulesData) >= 1) {
+        if (empty($modulesData)) {
             return [];
         }
 


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | Because of a bad `if` statement, modules' personal data were not displayed in `MANAGE CUSTOMER'S PERSONAL DATA` tab of the GDPR module configuration page.
| Type?         | bug fix
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | 
| How to test?  | 1. Be sure that `productcomments` and/or `ps_emailsubscription` module is installed and enabled<br>2. Go to *Improve > Module > Module Manager*<br>3. Look for `Official GDPR compliance` and click on *Configure*<br>4. On the `personal data management` tab, search for *John Doe* and click on it<br>5. You should have a section called`MODULE: PRODUCT COMMENTS` and/or `MODULE: NEWSLETTER SUBSCRIPTION` in the part that just opened.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
