### PR TITLE
Correct the customer details page link - PS 1.7.7.0

### DIFF
--- a/psgdpr.php
+++ b/psgdpr.php
@@ -412,7 +412,6 @@ class Psgdpr extends Module
 
         // assign var to smarty
         $this->context->smarty->assign([
-            'customer_link' => $this->context->link->getAdminLink('AdminCustomers', true) . '&viewcustomer&id_customer=',
             'module_name' => $this->name,
             'id_shop' => $id_shop,
             'module_version' => $this->version,

--- a/views/templates/admin/menu.tpl
+++ b/views/templates/admin/menu.tpl
@@ -70,7 +70,7 @@
     var psgdpr_adminController = "{$psgdpr_adminController|escape:'htmlall':'UTF-8'}";
     var adminControllerInvoices = "{$adminControllerInvoices|escape:'htmlall':'UTF-8'}";
     var ps_version = "{$isPs17|escape:'htmlall':'UTF-8'}";
-    var customer_link = "{$customer_link|escape:'htmlall':'UTF-8'}";
+    var customer_link = "{url entity='sf' route='admin_customers_view' sf-params=['customerId' => '0']}";
 
     var messageSuccessCopy = "{l s='Url has been copied to the clipboard!' mod='psgdpr' js=1}";
     var messageSuccessInvoices = "{l s='Invoices have been successfully downloaded.' mod='psgdpr' js=1}";

--- a/views/templates/admin/tabs/dataConfig.tpl
+++ b/views/templates/admin/tabs/dataConfig.tpl
@@ -122,7 +122,7 @@
                         <span class="text-muted">{l s='Orders number' mod='psgdpr'}: (( customer.nb_orders ))</span>
                     </div>
                     <div class="panel-footer">
-                        <a v-on:click.stop :href="customer_link+customer.id_customer" target="_blank" class="btn btn-default fancybox"><i class="icon-search"></i> {l s='Details' mod='psgdpr'}</a>
+                        <a v-on:click.stop :href="customer_link.replace(/\/0\//,'/'+customer.id_customer+'/')" target="_blank" class="btn btn-default fancybox"><i class="icon-search"></i> {l s='Details' mod='psgdpr'}</a>
                         <button type="button" v-on:click.stop="deleteCustomer('customer', customer.id_customer, index)" class="btn btn-danger pull-right"><i class="icon-trash"></i> {l s='Remove data' mod='psgdpr'}</button>
                         <a v-on:click.stop="downloadInvoices(customer.id_customer, index)" class="btn btn-primary pull-right"><i class="icon-download"></i> {l s='Download invoices' mod='psgdpr'}</a>
                     </div>


### PR DESCRIPTION

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | The link to the customer details page is broken because the Link::getAdminLink() return the new format link not compatible with legacy params. By the way, Link::getAdminLink() have to be corrected, it return always an url with token, although, the second param setted to false.
| Type?         | bug fix
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | -
| How to test?  | tested within PS 1.7.6.9 and 1.7.7.0

![x](https://user-images.githubusercontent.com/3179694/103160911-db24d980-47da-11eb-904b-1d3f4b102b33.jpg)

