### PR TITLE
"psgdpr" module is not registered to "actionExportGDPRData"

### DIFF
--- a/psgdpr.php
+++ b/psgdpr.php
@@ -895,7 +895,7 @@ class Psgdpr extends Module
     {
         $modulesData = Hook::getHookModuleExecList('actionExportGDPRData'); // get modules using the export gdpr hook
 
-        if (empty($modulesData) || count($modulesData) >= 1) {
+        if (empty($modulesData)) {
             return [];
         }
 


### PR DESCRIPTION
"psgdpr" module is not registered to "actionExportGDPRData", So, it is senseless to remove 1 from the hooked modules

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | Please be specific when describing the PR. <br> Every detail helps: versions, browser/server configuration, specific module/theme, etc. Feel free to add more information below this table.
| Type?         | bug fix / improvement / new feature / refacto / critical
| BC breaks?    | yes / no
| Deprecations? | yes / no
| Fixed ticket? | Fixes PrestaShop/Prestashop#{issue number here}.
| How to test?  | Please indicate how to best verify that this PR is correct.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
